### PR TITLE
Adding a link to the Oculi repository

### DIFF
--- a/marketing-analytics/understanding/oculi/README.md
+++ b/marketing-analytics/understanding/oculi/README.md
@@ -1,0 +1,16 @@
+**Note:** This is not an officially supported Google product. It is a reference
+implementation.
+
+# Oculi
+
+Oculi is a Google Cloud-based pipeline for tagging large sets of images or
+videos with labels based on their content, generating a BigQuery dataset for
+further analysis. Content tagging is done through Cloud's pre-trained computer
+vision models (Vision API and Video Intelligence API).
+
+The primary use case is for analyzing creatives (images and videos) in digital
+advertising. Combined with creative performance data, the output from this
+pipeline can be used to explore correlations between advertising content and
+performance (e.g. creatives with a human model tend to perform better).
+
+**Oculi is available in its own repository at github.com/google/oculi.**

--- a/marketing-analytics/understanding/oculi/README.md
+++ b/marketing-analytics/understanding/oculi/README.md
@@ -13,4 +13,4 @@ advertising. Combined with creative performance data, the output from this
 pipeline can be used to explore correlations between advertising content and
 performance (e.g. creatives with a human model tend to perform better).
 
-**Oculi is available in its own repository at github.com/google/oculi.**
+**Oculi is available in its own repository at [github.com/google/oculi](github.com/google/oculi).**

--- a/marketing-analytics/understanding/oculi/README.md
+++ b/marketing-analytics/understanding/oculi/README.md
@@ -13,4 +13,4 @@ advertising. Combined with creative performance data, the output from this
 pipeline can be used to explore correlations between advertising content and
 performance (e.g. creatives with a human model tend to perform better).
 
-**Oculi is available in its own repository at [github.com/google/oculi](github.com/google/oculi).**
+**Oculi is available in its own repository at [github.com/google/oculi](https://github.com/google/oculi).**


### PR DESCRIPTION
Creating a separate directory in marketing-analytics/understanding/ for Oculi, a gTech-developed solution in its own repository.